### PR TITLE
`req.RemoteAddr` should be in the `host:port` format

### DIFF
--- a/ridgenative.go
+++ b/ridgenative.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/textproto"
 	"net/url"
@@ -139,13 +140,20 @@ func (f *lambdaFunction) httpRequestV1(ctx context.Context, r *request) (*http.R
 		return nil, err
 	}
 
+	remoteHost := r.RequestContext.Identity.SourceIP
+	if remoteHost == "" {
+		// fallback to localhost if SourceIP is empty.
+		// Many middleware solutions treat 127.0.0.1 as a trusted proxy.
+		remoteHost = "127.0.0.1"
+	}
+
 	req := &http.Request{
 		Method:        r.HTTPMethod,
 		Proto:         "HTTP/1.0",
 		ProtoMajor:    1,
 		ProtoMinor:    0,
 		Header:        headers,
-		RemoteAddr:    r.RequestContext.Identity.SourceIP,
+		RemoteAddr:    net.JoinHostPort(remoteHost, "1234"),
 		ContentLength: contentLength,
 		Body:          body,
 		RequestURI:    uri,
@@ -186,13 +194,20 @@ func (f *lambdaFunction) httpRequestV2(ctx context.Context, r *request) (*http.R
 		return nil, err
 	}
 
+	remoteHost := r.RequestContext.Identity.SourceIP
+	if remoteHost == "" {
+		// fallback to localhost if SourceIP is empty.
+		// Many middleware solutions treat 127.0.0.1 as a trusted proxy.
+		remoteHost = "127.0.0.1"
+	}
+
 	req := &http.Request{
 		Method:        r.RequestContext.HTTP.Method,
 		Proto:         "HTTP/1.0",
 		ProtoMajor:    1,
 		ProtoMinor:    0,
 		Header:        headers,
-		RemoteAddr:    r.RequestContext.HTTP.SourceIP,
+		RemoteAddr:    net.JoinHostPort(remoteHost, "1234"),
 		ContentLength: contentLength,
 		Body:          body,
 		RequestURI:    rawURI,

--- a/ridgenative.go
+++ b/ridgenative.go
@@ -194,7 +194,7 @@ func (f *lambdaFunction) httpRequestV2(ctx context.Context, r *request) (*http.R
 		return nil, err
 	}
 
-	remoteHost := r.RequestContext.Identity.SourceIP
+	remoteHost := r.RequestContext.HTTP.SourceIP
 	if remoteHost == "" {
 		// fallback to localhost if SourceIP is empty.
 		// Many middleware solutions treat 127.0.0.1 as a trusted proxy.

--- a/ridgenative_test.go
+++ b/ridgenative_test.go
@@ -259,8 +259,8 @@ func TestHTTPRequest(t *testing.T) {
 		if httpReq.ContentLength != 0 {
 			t.Errorf("unexpected ContentLength: want %d, got %d", 0, httpReq.ContentLength)
 		}
-		if httpReq.RemoteAddr != "127.0.0.1:1234" {
-			t.Errorf("unexpected RemoteAddr: want %q, got %q", "127.0.0.1:1234", httpReq.RemoteAddr)
+		if httpReq.RemoteAddr != "192.0.2.1:1234" {
+			t.Errorf("unexpected RemoteAddr: want %q, got %q", "192.0.2.1:1234", httpReq.RemoteAddr)
 		}
 
 		body, err := io.ReadAll(httpReq.Body)
@@ -293,8 +293,8 @@ func TestHTTPRequest(t *testing.T) {
 		if httpReq.ContentLength != int64(len("{\"hello\":\"world\"}")) {
 			t.Errorf("unexpected ContentLength: want %d, got %d", int64(len("{\"hello\":\"world\"}")), httpReq.ContentLength)
 		}
-		if httpReq.RemoteAddr != "127.0.0.1:1234" {
-			t.Errorf("unexpected RemoteAddr: want %q, got %q", "127.0.0.1:1234", httpReq.RemoteAddr)
+		if httpReq.RemoteAddr != "192.0.2.1:1234" {
+			t.Errorf("unexpected RemoteAddr: want %q, got %q", "192.0.2.1:1234", httpReq.RemoteAddr)
 		}
 
 		body, err := io.ReadAll(httpReq.Body)
@@ -327,8 +327,8 @@ func TestHTTPRequest(t *testing.T) {
 		if httpReq.ContentLength != int64(len("{\"hello\":\"world\"}")) {
 			t.Errorf("unexpected ContentLength: want %d, got %d", int64(len("{\"hello\":\"world\"}")), httpReq.ContentLength)
 		}
-		if httpReq.RemoteAddr != "127.0.0.1:1234" {
-			t.Errorf("unexpected RemoteAddr: want %q, got %q", "127.0.0.1:1234", httpReq.RemoteAddr)
+		if httpReq.RemoteAddr != "192.0.2.1:1234" {
+			t.Errorf("unexpected RemoteAddr: want %q, got %q", "192.0.2.1:1234", httpReq.RemoteAddr)
 		}
 
 		body, err := io.ReadAll(httpReq.Body)
@@ -374,8 +374,8 @@ func TestHTTPRequest(t *testing.T) {
 		if httpReq.Host != "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.lambda-url.ap-northeast-1.on.aws" {
 			t.Errorf("unexpected host: want %q, got %q", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.lambda-url.ap-northeast-1.on.aws", httpReq.Host)
 		}
-		if httpReq.RemoteAddr != "127.0.0.1:1234" {
-			t.Errorf("unexpected RemoteAddr: want %q, got %q", "127.0.0.1:1234", httpReq.RemoteAddr)
+		if httpReq.RemoteAddr != "192.0.2.1:1234" {
+			t.Errorf("unexpected RemoteAddr: want %q, got %q", "192.0.2.1:1234", httpReq.RemoteAddr)
 		}
 	})
 
@@ -407,8 +407,8 @@ func TestHTTPRequest(t *testing.T) {
 		if httpReq.Host != "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.lambda-url.ap-northeast-1.on.aws" {
 			t.Errorf("unexpected host: want %q, got %q", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.lambda-url.ap-northeast-1.on.aws", httpReq.Host)
 		}
-		if httpReq.RemoteAddr != "127.0.0.1:1234" {
-			t.Errorf("unexpected RemoteAddr: want %q, got %q", "127.0.0.1:1234", httpReq.RemoteAddr)
+		if httpReq.RemoteAddr != "192.0.2.1:1234" {
+			t.Errorf("unexpected RemoteAddr: want %q, got %q", "192.0.2.1:1234", httpReq.RemoteAddr)
 		}
 	})
 
@@ -440,8 +440,8 @@ func TestHTTPRequest(t *testing.T) {
 		if httpReq.Host != "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.lambda-url.ap-northeast-1.on.aws" {
 			t.Errorf("unexpected host: want %q, got %q", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.lambda-url.ap-northeast-1.on.aws", httpReq.Host)
 		}
-		if httpReq.RemoteAddr != "127.0.0.1:1234" {
-			t.Errorf("unexpected RemoteAddr: want %q, got %q", "127.0.0.1:1234", httpReq.RemoteAddr)
+		if httpReq.RemoteAddr != "192.0.2.1:1234" {
+			t.Errorf("unexpected RemoteAddr: want %q, got %q", "192.0.2.1:1234", httpReq.RemoteAddr)
 		}
 	})
 }

--- a/ridgenative_test.go
+++ b/ridgenative_test.go
@@ -49,6 +49,10 @@ func TestHTTPRequest(t *testing.T) {
 		if httpReq.ContentLength != 0 {
 			t.Errorf("unexpected ContentLength: want %d, got %d", 0, httpReq.ContentLength)
 		}
+		if httpReq.RemoteAddr != "127.0.0.1:1234" {
+			t.Errorf("unexpected RemoteAddr: want %q, got %q", "127.0.0.1:1234", httpReq.RemoteAddr)
+		}
+
 		body, err := io.ReadAll(httpReq.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -79,6 +83,10 @@ func TestHTTPRequest(t *testing.T) {
 		if httpReq.ContentLength != int64(len("{\"hello\":\"world\"}")) {
 			t.Errorf("unexpected ContentLength: want %d, got %d", int64(len("{\"hello\":\"world\"}")), httpReq.ContentLength)
 		}
+		if httpReq.RemoteAddr != "127.0.0.1:1234" {
+			t.Errorf("unexpected RemoteAddr: want %q, got %q", "127.0.0.1:1234", httpReq.RemoteAddr)
+		}
+
 		body, err := io.ReadAll(httpReq.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -109,6 +117,10 @@ func TestHTTPRequest(t *testing.T) {
 		if httpReq.ContentLength != int64(len("{\"hello\":\"world\"}")) {
 			t.Errorf("unexpected ContentLength: want %d, got %d", int64(len("{\"hello\":\"world\"}")), httpReq.ContentLength)
 		}
+		if httpReq.RemoteAddr != "127.0.0.1:1234" {
+			t.Errorf("unexpected RemoteAddr: want %q, got %q", "127.0.0.1:1234", httpReq.RemoteAddr)
+		}
+
 		body, err := io.ReadAll(httpReq.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -142,6 +154,10 @@ func TestHTTPRequest(t *testing.T) {
 		if httpReq.ContentLength != 0 {
 			t.Errorf("unexpected ContentLength: want %d, got %d", 0, httpReq.ContentLength)
 		}
+		if httpReq.RemoteAddr != "192.0.2.1:1234" {
+			t.Errorf("unexpected RemoteAddr: want %q, got %q", "192.0.2.1:1234", httpReq.RemoteAddr)
+		}
+
 		body, err := io.ReadAll(httpReq.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -172,6 +188,10 @@ func TestHTTPRequest(t *testing.T) {
 		if httpReq.ContentLength != int64(len("{\"hello\":\"world\"}")) {
 			t.Errorf("unexpected ContentLength: want %d, got %d", int64(len("{\"hello\":\"world\"}")), httpReq.ContentLength)
 		}
+		if httpReq.RemoteAddr != "192.0.2.1:1234" {
+			t.Errorf("unexpected RemoteAddr: want %q, got %q", "192.0.2.1:1234", httpReq.RemoteAddr)
+		}
+
 		body, err := io.ReadAll(httpReq.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -202,6 +222,10 @@ func TestHTTPRequest(t *testing.T) {
 		if httpReq.ContentLength != int64(len("{\"hello\":\"world\"}")) {
 			t.Errorf("unexpected ContentLength: want %d, got %d", int64(len("{\"hello\":\"world\"}")), httpReq.ContentLength)
 		}
+		if httpReq.RemoteAddr != "192.0.2.1:1234" {
+			t.Errorf("unexpected RemoteAddr: want %q, got %q", "192.0.2.1:1234", httpReq.RemoteAddr)
+		}
+
 		body, err := io.ReadAll(httpReq.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -235,6 +259,10 @@ func TestHTTPRequest(t *testing.T) {
 		if httpReq.ContentLength != 0 {
 			t.Errorf("unexpected ContentLength: want %d, got %d", 0, httpReq.ContentLength)
 		}
+		if httpReq.RemoteAddr != "127.0.0.1:1234" {
+			t.Errorf("unexpected RemoteAddr: want %q, got %q", "127.0.0.1:1234", httpReq.RemoteAddr)
+		}
+
 		body, err := io.ReadAll(httpReq.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -265,6 +293,10 @@ func TestHTTPRequest(t *testing.T) {
 		if httpReq.ContentLength != int64(len("{\"hello\":\"world\"}")) {
 			t.Errorf("unexpected ContentLength: want %d, got %d", int64(len("{\"hello\":\"world\"}")), httpReq.ContentLength)
 		}
+		if httpReq.RemoteAddr != "127.0.0.1:1234" {
+			t.Errorf("unexpected RemoteAddr: want %q, got %q", "127.0.0.1:1234", httpReq.RemoteAddr)
+		}
+
 		body, err := io.ReadAll(httpReq.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -295,6 +327,10 @@ func TestHTTPRequest(t *testing.T) {
 		if httpReq.ContentLength != int64(len("{\"hello\":\"world\"}")) {
 			t.Errorf("unexpected ContentLength: want %d, got %d", int64(len("{\"hello\":\"world\"}")), httpReq.ContentLength)
 		}
+		if httpReq.RemoteAddr != "127.0.0.1:1234" {
+			t.Errorf("unexpected RemoteAddr: want %q, got %q", "127.0.0.1:1234", httpReq.RemoteAddr)
+		}
+
 		body, err := io.ReadAll(httpReq.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -338,6 +374,9 @@ func TestHTTPRequest(t *testing.T) {
 		if httpReq.Host != "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.lambda-url.ap-northeast-1.on.aws" {
 			t.Errorf("unexpected host: want %q, got %q", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.lambda-url.ap-northeast-1.on.aws", httpReq.Host)
 		}
+		if httpReq.RemoteAddr != "127.0.0.1:1234" {
+			t.Errorf("unexpected RemoteAddr: want %q, got %q", "127.0.0.1:1234", httpReq.RemoteAddr)
+		}
 	})
 
 	t.Run("function urls post request", func(t *testing.T) {
@@ -368,6 +407,9 @@ func TestHTTPRequest(t *testing.T) {
 		if httpReq.Host != "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.lambda-url.ap-northeast-1.on.aws" {
 			t.Errorf("unexpected host: want %q, got %q", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.lambda-url.ap-northeast-1.on.aws", httpReq.Host)
 		}
+		if httpReq.RemoteAddr != "127.0.0.1:1234" {
+			t.Errorf("unexpected RemoteAddr: want %q, got %q", "127.0.0.1:1234", httpReq.RemoteAddr)
+		}
 	})
 
 	t.Run("function urls base64 request", func(t *testing.T) {
@@ -397,6 +439,9 @@ func TestHTTPRequest(t *testing.T) {
 		}
 		if httpReq.Host != "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.lambda-url.ap-northeast-1.on.aws" {
 			t.Errorf("unexpected host: want %q, got %q", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.lambda-url.ap-northeast-1.on.aws", httpReq.Host)
+		}
+		if httpReq.RemoteAddr != "127.0.0.1:1234" {
+			t.Errorf("unexpected RemoteAddr: want %q, got %q", "127.0.0.1:1234", httpReq.RemoteAddr)
 		}
 	})
 }


### PR DESCRIPTION
Example source code:

```go
package main

import (
	"io"
	"net/http"

	"github.com/shogo82148/ridgenative"
)

func main() {
	http.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
		io.WriteString(w, r.RemoteAddr)
	})
	ridgenative.ListenAndServe(":8080", nil)
}
```

When the server runs locally, `r.RemoteAddr` is in the `host:port` format.

```plain
$ go run main.go
$ curl http://localhost:8080
[::1]:54493
```

When I deploy to AWS Lambda, `r.RemoteAddr` is in the `host` format.

```plain
$ curl https://xxxxxx.lambda-url.ap-northeast-1.on.aws/
192.0.2.1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how client IP information is represented in outgoing HTTP requests, ensuring consistent `RemoteAddr` values across request types.
  * Added a safe fallback (`127.0.0.1`) when no source IP is available, avoiding empty remote address fields.
  * Normalized `RemoteAddr` formatting to `host:1234` for improved compatibility.
  * Updated tests to validate the new `RemoteAddr` behavior for ALB, API Gateway v1/v2, and Function URL scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->